### PR TITLE
feat: 228 update ble emulator docs to match wifi_v2 service

### DIFF
--- a/api.eyeofthetiga.com/Guides/BaseStation.md
+++ b/api.eyeofthetiga.com/Guides/BaseStation.md
@@ -1,13 +1,13 @@
 
 # Bluetooth Documentation
 
-### Reference
+## Reference
 
 * [Assigned Numbers](https://www.bluetooth.com/specifications/assigned-numbers/)
 * [Appearance Values](https://specificationrefs.bluetooth.com/assigned-values/Appearance%20Values.pdf)
 
-
 # About the BaseStation Emulator
+
 # GATT WIFI Service
 
 | Allocated UUID | Description                     | Attributes  |
@@ -18,27 +18,30 @@
 | `0xD003`       | Network List of Available SSIDs | notify      |
 | `0xD004`       | Trigger a Connection Attempt    | write       |
 | `0xD005`       | Connection Status               | read,notify |
-<br>
+<br/>  
 
 ## 0xD000 WIFI Service
 
-If the emulator is started with `--no-networks`, then no networks will be shown for `0xD003` 
+If the emulator is started with `--no-networks`, then no networks will be shown for `0xD003`
 network list of available ssids.
 
-Writing the `0xD001` and `0xD002` characteristics will not be enough to start a network connection attempt, `0xD004` should be written to to trigger a network connection attempt. 
+Writing the `0xD001` and `0xD002` characteristics will not be enough to start a network connection attempt, `0xD004` should be written to to trigger a network connection attempt.
 <br>
 
 ## 0xD001 Network SSID
+
 | Defined Submissions   | Description                                                                                                              |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `"Happy Path"`        | All passwords work on this network, `0xD005` will always notify as `CONNECTED` after `0xD004` is set                     |
 | `"Bad Network"`       | After `0xD004` is set, then `0xD005` will always notify as `NETWORK_ERROR`                                               |
 | `"Firewall"`          | After `0xD004` is set, then `0xD005` will always notify as `CONNECTION_ERROR`                                            |
-| `"Bad Password"`      | After `0xD004` is set, then `0xD005` will always notify as `NETWORK_ERROR` (or `PASSWORD_ERROR` if we can figure it out) |
-| `"Duplicate_Network"` | After `0xD004` is set, then `0xD005` will always notify as `NETWORK_ERROR`                                               |
+| `"Bad Password"`      | After `0xD004` is set, then `0xD005` will always notify as `NETWORK_ERROR | PASSWORD_ERROR`                              |
+| `"Duplicate Network"` | After `0xD004` is set, then `0xD005` will always notify as `NETWORK_ERROR`                                               |
+| `"Error Network"`     | After `0xD004` is set, then `0xD005` will always notify as `SOFTWARE_ERROR`                                              |
 <br>
 
 ## 0xD002 Password
+
 Password behaviour for the emulator is defined based on the `0xD001` service
 <br>
 
@@ -49,15 +52,17 @@ Subscribe will notify for each network found, listener should handle duplicate n
 Will not notify if network is no longer available.
 
 The following networks will be presented:
+
 * `"Happy Path"`
 * `"Bad Password"`
 * `"Bad Network"`
 * `"Firewall"`
 * `"Duplicate Network"`
 * `"Duplicate Network"`
+* `"Error Network"`
 <br>
 
-##  0xD004 Trigger a Connection Attempt
+## 0xD004 Trigger a Connection Attempt
 
 Write any value to start a connection
 | Defined Submissions          | Description                            | Behaviour of other Characteristics |
@@ -70,17 +75,21 @@ Write any value to start a connection
 Get or watch the connection status
 
 
-| Defined Connection Statuses | Description                                                                                 |
-| --------------------------- | ------------------------------------------------------------------------------------------- |
-| `NOT_CONNECTED`             | The default state of the base station                                                       |
-| `CONNECTING`                | The base station is attempting to establish a connection and confirm connectivity to our servers |
-| `NETWORK_ERROR`             | Unable to connect to the network, check your credentials                                    |
-| `CONNECTION_ERROR`          | Base station connected to the network, but is unable to reach our servers                        |
-| `CONNECTED`                 | Full connection is established                                                              |
+| Defined Connection Statuses | Description                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------------- |
+| `NOT_CONNECTED`             | The default state of the base station                                                             |
+| `CONNECTING`                | The base station is attempting to establish a connection and confirm connectivity to our servers  |
+| `SOFTWARE_ERROR`            | An unexpected error occured while connecting                                                      |
+| `PASSWORD_ERROR`            | User password is incorrect, this event is not available for all access points (see NETWORK_ERROR) |
+| `NETWORK_ERROR`             | Unable to connect to the network, this may mean incorrect SSID or Password                        |
+| `CONNECTION_ERROR`          | Base station connected to the network, but is unable to reach our servers                         |
+| `CONNECTED`                 | Full connection is established                                                                    |
+<br/>
 
-* `PASSWORD_ERROR` * user password was incorrect -- (put a hold on this for now)
+## User Experience
 
-<br><br>
+If a `SOFTWARE_ERROR` is received, the user should be told to retry the connection and if the issue persists they should contact plantiga support.
+If a `PASSWORD_ERROR` or `NETWORK_ERROR` is received, the user should be told to check their Password and retry the connection.
 
 # GATT API Key Service
 
@@ -106,7 +115,7 @@ Get or watch the connection status
 
 | Possible Values      | Description                                                                            |
 | -------------------- | -------------------------------------------------------------------------------------- |
-| `NO_KEY`             | `0xD101` has not been written to                                                       |
+| `NOT_SET`            | `0xD101` has not been written to                                                       |
 | `KEY_OK`             | `0xD101` is valid                                                                      |
 | `KEY_INVALID`        | `0xD101` is invalid                                                                    |
 | `CONNECTION_TIMEOUT` | `0xD101` may be correct, but there was a network error when attempting to authenticate |


### PR DESCRIPTION
Resolves https://github.com/Plantiga/CloudAdapter/issues/228

cc @ahollist 

### Checklist:

* [x] The readme and documentation has been updated or does not need to be updated
* [x] This change has been communicated with the team if needed (discussed in meeting with Sean, Andrew, Derek and Rowan)
* [x] I have linked to the original issue
* [ ] I have added tests to cover my changes
* [x] This PR does not need notes or I've added them below
* [x] This PR does not need extra testing from our release testing process or I've added a 'tests' section below

## Release
This should not be merged until the emulator has been updated to match the behaviour.